### PR TITLE
RANCHER-2321: Align pom.xml with template pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>app-reporting</name>
+  <name>${project.name}</name>
   <artifactId>app-reporting</artifactId>
   <groupId>org.folio</groupId>
   <description>Reporting app for FOLIO Sunflower</description>
   <version>1.2.0</version>
 
   <properties>
+    <project.name>app-reporting</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <folio-application-generator.version>1.1.0</folio-application-generator.version>
+    <templatePath>${basedir}/${project.name}.template.json</templatePath>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
   </properties>
 
@@ -28,7 +30,7 @@
           </execution>
         </executions>
         <configuration>
-          <templatePath>${basedir}/app-reporting.template.json</templatePath>
+          <templatePath>${templatePath}</templatePath>
           <moduleRegistries>
             <registry>
               <type>okapi</type>
@@ -91,9 +93,9 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://https://github.com/folio-org/app-reporting</url>
-    <connection>scm:git:git://github.com:folio-org/app-reporting.git</connection>
-    <developerConnection>scm:git:git@github.com:folio-org/app-reporting.git</developerConnection>
+    <url>https://github.com/folio-org/${project.name}</url>
+    <connection>scm:git:git://github.com:folio-org/${project.name}.git</connection>
+    <developerConnection>scm:git:git@github.com:folio-org/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 </project>


### PR DESCRIPTION
Aligns app-reporting pom.xml with template pattern for Maven parameter passing.

**Changes:**
- Add project.name and templatePath properties  
- Update configuration to use ${templatePath} and ${project.name}
- Fix SCM URLs and double https:// protocol

**Benefits:**
- Enables Maven parameter overriding
- Standardizes naming across repositories
- Supports automated workflows

**Related:** RANCHER-2321